### PR TITLE
Clean up implementation if same struct type check.

### DIFF
--- a/automapper.go
+++ b/automapper.go
@@ -58,7 +58,7 @@ func MapLoose(source, dest interface{}) {
 
 func mapValues(sourceVal, destVal reflect.Value, loose bool) {
 	destType := destVal.Type()
-	if destType.Kind() == reflect.Struct && !sourceTypeEqualsDestType(sourceVal, destVal) {
+	if destType.Kind() == reflect.Struct && sourceVal.Type() != destVal.Type() {
 		if sourceVal.Type().Kind() == reflect.Ptr {
 			if sourceVal.IsNil() {
 				// If source is nil, it maps to an empty struct

--- a/automapper_test.go
+++ b/automapper_test.go
@@ -257,15 +257,15 @@ func TestWithLooseOption(t *testing.T) {
 	assert.Equal(t, dest.Bar, 0)
 }
 
-func TestStructCanBeSet(t *testing.T) {
-	type MainType struct {
+func TestSetStructOfSameTypeDirectly(t *testing.T) {
+	type FooType struct {
 		time.Time
 	}
 	source := struct {
-		Foo MainType
-	}{MainType{Time: time.Now().UTC()}}
+		Foo FooType
+	}{FooType{Time: time.Now().UTC()}}
 	dest := struct {
-		Foo MainType
+		Foo FooType
 	}{}
 	Map(&source, &dest)
 	assert.Equal(t, source.Foo.String(), dest.Foo.String())


### PR DESCRIPTION
Bring fork codebase inline with merge request to forked codebase (https://github.com/stroiman/go-automapper/pull/6).