### PR TITLE
Rename skip tag from "skip" to "-"

### DIFF
--- a/automapper.go
+++ b/automapper.go
@@ -117,7 +117,7 @@ func mapField(source, destVal reflect.Value, i int, loose bool) {
 		}
 	}()
 
-	if automapperTag, ok := destTypeField.Tag.Lookup("automapper"); ok && automapperTag == "skip" {
+	if automapperTag, ok := destTypeField.Tag.Lookup("automapper"); ok && automapperTag == "-" {
 		return
 	}
 

--- a/automapper_test.go
+++ b/automapper_test.go
@@ -290,7 +290,7 @@ func TestSkip(t *testing.T) {
 	}{"abc"}
 	dest := struct {
 		Foo string
-		Bar string `automapper:"skip"`
+		Bar string `automapper:"-"`
 	}{}
 	Map(&source, &dest)
 	assert.Empty(t, dest.Bar)


### PR DESCRIPTION
Rename skip tag from "skip" to "-" to be more consistent with the Go ecosystem.