### PR TITLE
Add mapping option to use to map by source members instead of destination members

### DIFF
--- a/automapper.go
+++ b/automapper.go
@@ -70,27 +70,14 @@ func MapWithOptions(source, dest interface{}, opts MapOptions) {
 // behavior - but I'd rather not add that functionality before I have a better
 // idea what is a good options format.
 func MapLoose(source, dest interface{}) {
-	MapLooseWithOptions(source, dest, MapOptions{})
-}
-
-// MapLooseWithOptions works just like Map, except it doesn't fail when the destination
-// type contains fields not supplied by the source.
-//
-// This function is meant to be a temporary solution - the general idea is
-// that the Map function should take a number of options that can modify its
-// behavior - but I'd rather not add that functionality before I have a better
-// idea what is a good options format.
-func MapLooseWithOptions(source, dest interface{}, opts MapOptions) {
 	var destType = reflect.TypeOf(dest)
 	if destType.Kind() != reflect.Ptr {
 		panic("Dest must be a pointer type")
 	}
 	var sourceVal = reflect.ValueOf(source)
 	var destVal = reflect.ValueOf(dest).Elem()
-	opts.loose = true
-	mapValues(sourceVal, destVal, opts)
+	mapValues(sourceVal, destVal, MapOptions{loose: true})
 }
-
 func mapValues(sourceVal, destVal reflect.Value, opts MapOptions) {
 	sourceType := sourceVal.Type()
 	destType := destVal.Type()

--- a/automapper.go
+++ b/automapper.go
@@ -15,6 +15,10 @@ import (
 	"reflect"
 )
 
+type MapOptions struct {
+	UseSourceMemberList bool
+}
+
 // Map fills out the fields in dest with values from source. All fields in the
 // destination object must exist in the source object.
 //
@@ -30,13 +34,31 @@ import (
 // destination to ensure that a renamed field in either the source or
 // destination does not result in subtle silent bug.
 func Map(source, dest interface{}) {
+	MapWithOptions(source, dest, MapOptions{})
+}
+
+// MapWithOptions fills out the fields in dest with values from source. All fields in the
+// destination object must exist in the source object.
+//
+// Object hierarchies with nested structs and slices are supported, as long as
+// type types of nested structs/slices follow the same rules, i.e. all fields
+// in destination structs must be found on the source struct.
+//
+// Embedded/anonymous structs are supported
+//
+// Values that are not exported/not public will not be mapped.
+//
+// It is a design decision to panic when a field cannot be mapped in the
+// destination to ensure that a renamed field in either the source or
+// destination does not result in subtle silent bug.
+func MapWithOptions(source, dest interface{}, opt MapOptions) {
 	var destType = reflect.TypeOf(dest)
 	if destType.Kind() != reflect.Ptr {
 		panic("Dest must be a pointer type")
 	}
 	var sourceVal = reflect.ValueOf(source)
 	var destVal = reflect.ValueOf(dest).Elem()
-	mapValues(sourceVal, destVal, false)
+	mapValues(sourceVal, destVal, false, opt.UseSourceMemberList)
 }
 
 // MapLoose works just like Map, except it doesn't fail when the destination
@@ -47,67 +69,88 @@ func Map(source, dest interface{}) {
 // behavior - but I'd rather not add that functionality before I have a better
 // idea what is a good options format.
 func MapLoose(source, dest interface{}) {
+	MapLooseWithOptions(source, dest, MapOptions{})
+}
+
+// MapLooseWithOptions works just like Map, except it doesn't fail when the destination
+// type contains fields not supplied by the source.
+//
+// This function is meant to be a temporary solution - the general idea is
+// that the Map function should take a number of options that can modify its
+// behavior - but I'd rather not add that functionality before I have a better
+// idea what is a good options format.
+func MapLooseWithOptions(source, dest interface{}, opt MapOptions) {
 	var destType = reflect.TypeOf(dest)
 	if destType.Kind() != reflect.Ptr {
 		panic("Dest must be a pointer type")
 	}
 	var sourceVal = reflect.ValueOf(source)
 	var destVal = reflect.ValueOf(dest).Elem()
-	mapValues(sourceVal, destVal, true)
+	mapValues(sourceVal, destVal, true, opt.UseSourceMemberList)
 }
 
-func mapValues(sourceVal, destVal reflect.Value, loose bool) {
+func mapValues(sourceVal, destVal reflect.Value, loose, useSourceMemberList bool) {
+	sourceType := sourceVal.Type()
 	destType := destVal.Type()
-	if destType.Kind() == reflect.Struct && sourceVal.Type() != destVal.Type() {
-		if sourceVal.Type().Kind() == reflect.Ptr {
-			if sourceVal.IsNil() {
-				// If source is nil, it maps to an empty struct
-				sourceVal = reflect.New(sourceVal.Type().Elem())
-			}
-			sourceVal = sourceVal.Elem()
+	if destType.Kind() == reflect.Struct && sourceVal.Type().Kind() == reflect.Ptr {
+		if sourceVal.IsNil() {
+			sourceVal = reflect.New(sourceType.Elem())
 		}
-		for i := 0; i < destVal.NumField(); i++ {
-			mapField(sourceVal, destVal, i, loose)
-		}
-	} else if destType == sourceVal.Type() {
+		sourceVal = sourceVal.Elem()
+		mapValues(sourceVal, destVal, loose, useSourceMemberList)
+	} else if destType == sourceType {
 		destVal.Set(sourceVal)
+	} else if destType.Kind() == reflect.Struct && sourceType.Kind() == reflect.Struct {
+		mapFields(sourceVal, destVal, loose, useSourceMemberList)
 	} else if destType.Kind() == reflect.Ptr {
 		if valueIsNil(sourceVal) {
 			return
 		}
 		val := reflect.New(destType.Elem())
-		mapValues(sourceVal, val.Elem(), loose)
+		mapValues(sourceVal, val.Elem(), loose, useSourceMemberList)
 		destVal.Set(val)
 	} else if destType.Kind() == reflect.Slice {
-		mapSlice(sourceVal, destVal, loose)
+		mapSlice(sourceVal, destVal, loose, useSourceMemberList)
 	} else {
 		destVal.Set(sourceVal.Convert(destType))
 	}
 }
 
-func mapSlice(sourceVal, destVal reflect.Value, loose bool) {
+func mapSlice(sourceVal, destVal reflect.Value, loose, useSourceMemberList bool) {
 	destType := destVal.Type()
 	length := sourceVal.Len()
 	target := reflect.MakeSlice(destType, length, length)
 	for j := 0; j < length; j++ {
 		val := reflect.New(destType.Elem()).Elem()
-		mapValues(sourceVal.Index(j), val, loose)
+		mapValues(sourceVal.Index(j), val, loose, useSourceMemberList)
 		target.Index(j).Set(val)
 	}
 
 	if length == 0 {
-		verifyArrayTypesAreCompatible(sourceVal, destVal, loose)
+		verifyArrayTypesAreCompatible(sourceVal, destVal, loose, useSourceMemberList)
 	}
 	destVal.Set(target)
 }
 
-func verifyArrayTypesAreCompatible(sourceVal, destVal reflect.Value, loose bool) {
+func verifyArrayTypesAreCompatible(sourceVal, destVal reflect.Value, loose, useSourceMemberList bool) {
 	dummyDest := reflect.New(reflect.PtrTo(destVal.Type()))
 	dummySource := reflect.MakeSlice(sourceVal.Type(), 1, 1)
-	mapValues(dummySource, dummyDest.Elem(), loose)
+	mapValues(dummySource, dummyDest.Elem(), loose, useSourceMemberList)
 }
 
-func mapField(source, destVal reflect.Value, i int, loose bool) {
+func mapFields(sourceVal, destVal reflect.Value, loose, useSourceMemberList bool) {
+	if useSourceMemberList {
+		for i := 0; i < sourceVal.NumField(); i++ {
+			mapSourceField(sourceVal, destVal, i, loose, useSourceMemberList)
+		}
+	} else {
+		for i := 0; i < destVal.NumField(); i++ {
+			mapDestField(sourceVal, destVal, i, loose, useSourceMemberList)
+		}
+	}
+}
+
+func mapDestField(source, destVal reflect.Value, i int, loose, useSourceMemberList bool) {
 	destType := destVal.Type()
 	destTypeField := destType.Field(i)
 	fieldName := destTypeField.Name
@@ -123,7 +166,7 @@ func mapField(source, destVal reflect.Value, i int, loose bool) {
 
 	destField := destVal.Field(i)
 	if destType.Field(i).Anonymous {
-		mapValues(source, destField, loose)
+		mapValues(source, destField, loose, useSourceMemberList)
 	} else {
 		if valueIsContainedInNilEmbeddedType(source, fieldName) {
 			return
@@ -134,7 +177,7 @@ func mapField(source, destVal reflect.Value, i int, loose bool) {
 				return
 			}
 			if destField.Kind() == reflect.Struct {
-				mapValues(source, destField, loose)
+				mapValues(source, destField, loose, useSourceMemberList)
 				return
 			} else {
 				for i := 0; i < source.NumField(); i++ {
@@ -147,8 +190,28 @@ func mapField(source, destVal reflect.Value, i int, loose bool) {
 				}
 			}
 		}
-		mapValues(sourceField, destField, loose)
+		mapValues(sourceField, destField, loose, useSourceMemberList)
 	}
+}
+func mapSourceField(source, destVal reflect.Value, i int, loose, useSourceMemberList bool) {
+	sourceType := source.Type()
+	sourceTypeField := sourceType.Field(i)
+	fieldName := sourceTypeField.Name
+	defer func() {
+		if r := recover(); r != nil {
+			panic(fmt.Sprintf("Error mapping field: %s. DestType: %v. SourceType: %v. Error: %v", fieldName, destVal.Type(), sourceType, r))
+		}
+	}()
+
+	sourceFieldName := source.Type().Field(i).Name
+	for q := 0; q < destVal.Type().NumField(); q++ {
+		destFieldName := destVal.Type().Field(q).Name
+		if sourceFieldName == destFieldName {
+			mapDestField(source, destVal, q, loose, useSourceMemberList)
+			return
+		}
+	}
+	panic("destination has no field that matches source field")
 }
 
 func valueIsNil(value reflect.Value) bool {

--- a/automapper_test.go
+++ b/automapper_test.go
@@ -296,6 +296,43 @@ func TestSkip(t *testing.T) {
 	assert.Empty(t, dest.Bar)
 }
 
+func TestMapSourceField_DestContainsUnmappedFields(t *testing.T) {
+	source := struct {
+		Foo string
+	}{"abc"}
+	dest := struct {
+		Foo string
+		Bar string
+	}{}
+	MapWithOptions(&source, &dest, MapOptions{UseSourceMemberList: true})
+	assert.Equal(t, source.Foo, dest.Foo)
+}
+
+func TestMapSourceField_Panics(t *testing.T) {
+	defer func() { recover() }()
+	source := struct {
+		Foo string
+	}{"abc"}
+	dest := struct {
+	}{}
+	MapWithOptions(&source, &dest, MapOptions{UseSourceMemberList: true})
+	t.Error("Should have panicked")
+}
+
+func TestMapSourceField_SkipsOnlyOnDestinationTag(t *testing.T) {
+	source := struct {
+		Foo string
+		Bar string `automapper:"-"`
+	}{"abc", "def"}
+	dest := struct {
+		Foo string `automapper:"-"`
+		Bar string
+	}{}
+	MapWithOptions(&source, &dest, MapOptions{UseSourceMemberList: true})
+	assert.Empty(t, dest.Foo)
+	assert.Equal(t, source.Bar, dest.Bar)
+}
+
 type SourceParent struct {
 	Children []SourceTypeA
 }


### PR DESCRIPTION
The only thing this change does is that the source members of structs are looped and mapped, instead of the destination members. All other rules (skipping etc) only apply to the destination values.